### PR TITLE
gdb-server: Create arch-specific structure type for every feature

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -2200,14 +2200,11 @@ static int gdb_generate_target_description(struct target *target, char **tdesc_o
 	int reg_list_size;
 	char const *architecture;
 	char const **features = NULL;
-	char const **arch_defined_types = NULL;
 	int feature_list_size = 0;
-	int num_arch_defined_types = 0;
 	char *tdesc = NULL;
 	int pos = 0;
 	int size = 0;
 
-	arch_defined_types = calloc(1, sizeof(char *));
 
 	retval = target_get_gdb_reg_list(target, &reg_list,
 			&reg_list_size, REG_CLASS_ALL);
@@ -2249,7 +2246,10 @@ static int gdb_generate_target_description(struct target *target, char **tdesc_o
 	/* generate target description according to register list */
 	if (features != NULL) {
 		while (features[current_feature]) {
+			char const **arch_defined_types = NULL;
+			int num_arch_defined_types = 0;
 
+			arch_defined_types = calloc(1, sizeof(char *));
 			xml_printf(&retval, &tdesc, &pos, &size,
 					"<feature name=\"%s\">\n",
 					features[current_feature]);
@@ -2314,6 +2314,7 @@ static int gdb_generate_target_description(struct target *target, char **tdesc_o
 					"</feature>\n");
 
 			current_feature++;
+			free(arch_defined_types);
 		}
 	}
 
@@ -2323,7 +2324,6 @@ static int gdb_generate_target_description(struct target *target, char **tdesc_o
 error:
 	free(features);
 	free(reg_list);
-	free(arch_defined_types);
 
 	if (retval == ERROR_OK)
 		*tdesc_out = tdesc;


### PR DESCRIPTION
This change was reviewed upstream here http://openocd.zylin.com/#/c/5179/ and currently is awaiting for being merged.

As it is mentioned here [1] type's ID is unique name within containing feature.

That said if regs of the same type located in different features it's required
to insert type definition at least in each feature.

See more details in discussion here [2].

[1] https://sourceware.org/gdb/onlinedocs/gdb/Target-Description-Format.html#Types
[2] https://github.com/foss-for-synopsys-dwc-arc-processors/openocd/commit/2a5f5125ac8fa0e1359b6be03b209f9f5d1ade82#r33460077