### PR TITLE
rtos: fix Zephyr autodetecting routine

### DIFF
--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -51,8 +51,8 @@ static struct rtos_type *rtos_types[] = {
 	&mqx_rtos,
 	&uCOS_III_rtos,
 	&nuttx_rtos,
-	&hwthread_rtos,
 	&Zephyr_rtos,
+	&hwthread_rtos,
 	NULL
 };
 


### PR DESCRIPTION
Recently introduced hwthread_rtos broke the process of RTOS autodetection
for Zephyr. There is a lack of symbols to look up in this RTOS:
  https://github.com/zephyrproject-rtos/openocd/blob/zephyr-20191003/src/rtos/hwthread.c#L268
This lack cause execution of this branch:
  https://github.com/zephyrproject-rtos/openocd/blob/zephyr-20191003/src/rtos/rtos.c#L263
After that "No RTOS could be auto-detected!" message is printed and Zephyr RTOS
is not detected as expected.

With this commit we introduce the workaround which consists in moving
hwthread_rtos at the end of rtos_types[] list.

Signed-off-by: Evgeniy Didin <didin@synopsys.com>