### PR TITLE
tcl: Introduce ARCv2 HSDK board support

### DIFF
--- a/src/target/arc32.h
+++ b/src/target/arc32.h
@@ -136,12 +136,18 @@ struct arc32_common {
 
 	/* Cache control */
 	bool has_dcache;
+	bool has_l2cache;
 	/* If true, then D$ has been already flushed since core has been
 	 * halted. */
 	bool dcache_flushed;
+	/* If true, then L2 has been already flushed since core has been
+	 * halted. */
+	bool l2cache_flushed;
 	/* If true, then caches have been already flushed since core has been
 	 * halted. */
-	bool cache_invalidated;
+	bool icache_invalidated;
+	bool dcache_invalidated;
+	bool l2cache_invalidated;
 
 	/* Whether DEBUG.SS bit is present. This is a unique feature of ARC 600. */
 	bool has_debug_ss;
@@ -280,13 +286,13 @@ int arc32_start_core(struct target *target);
 int arc32_config_step(struct target *target, int enable_step);
 
 int arc32_cache_invalidate(struct target *target);
+int arc32_cache_flush(struct target *target);
 
 int arc32_wait_until_core_is_halted(struct target *target);
 
 int arc32_print_core_state(struct target *target);
 int arc32_arch_state(struct target *target);
 int arc32_get_current_pc(struct target *target);
-int arc32_dcache_flush(struct target *target);
 
 int arc32_reset_caches_states(struct target *target);
 

--- a/src/target/arc_dbg.c
+++ b/src/target/arc_dbg.c
@@ -547,6 +547,11 @@ int arc_dbg_halt(struct target *target)
 	target->state = TARGET_HALTED;
 	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 
+	/* We need to reset ARC cache variables so caches
+	 * would be flushed on read and actual data
+	 * would be placed in memory. */
+	arc32_reset_caches_states(target);
+
 	return ERROR_OK;
 }
 
@@ -588,6 +593,10 @@ int arc_dbg_resume(struct target *target, int current, target_addr_t address,
 		resume_pc = buf_get_u32(pc->value,
 			0, 32);
 
+	/* We need to reset ARC cache variables so caches
+	 * would be invalidated and actual data
+	 * would be fetched from memory. */
+	arc32_reset_caches_states(target);
 	arc32_restore_context(target);
 
 	LOG_DEBUG("Target resumes from PC=0x%" PRIx32 ", pc.dirty=%i, pc.valid=%i",

--- a/src/target/arc_mem.c
+++ b/src/target/arc_mem.c
@@ -55,9 +55,9 @@ static int arc_mem_read_block(struct target *target, target_addr_t addr,
 	assert(!(addr & 3));
 	assert(size == 4);
 
-	/* Always call D$ flush, it will decide whether to perform actual
+	/* Always call D$/L2 flush, it will decide whether to perform actual
 	 * flush. */
-	CHECK_RETVAL(arc32_dcache_flush(target));
+	CHECK_RETVAL(arc32_cache_flush(target));
 	CHECK_RETVAL(arc_jtag_read_memory(&arc32->jtag_info, addr, count, buf,
 		    arc_mem_is_slow_memory(arc32, addr, size, count)));
 
@@ -98,8 +98,8 @@ static int arc_mem_write_block16(struct target *target, uint32_t addr,
 	/* Check arguments */
 	assert(!(addr & 1));
 
-	/* We will read data from memory, so we need to flush D$. */
-	CHECK_RETVAL(arc32_dcache_flush(target));
+	/* We will read data from memory, so we need to flush the cache. */
+	CHECK_RETVAL(arc32_cache_flush(target));
 
 	uint32_t buffer_he;
 	uint8_t buffer_te[sizeof(uint32_t)];
@@ -149,8 +149,8 @@ static int arc_mem_write_block8(struct target *target, uint32_t addr,
 	LOG_DEBUG("Write 1-byte memory block: addr=0x%08" PRIx32 ", count=%" PRIu32,
 			addr, count);
 
-	/* We will read data from memory, so we need to flush D$. */
-	CHECK_RETVAL(arc32_dcache_flush(target));
+	/* We will read data from memory, so we need to flush the cache. */
+	CHECK_RETVAL(arc32_cache_flush(target));
 
 	uint32_t buffer_he;
 	uint8_t buffer_te[sizeof(uint32_t)];

--- a/src/target/arc_mntr.c
+++ b/src/target/arc_mntr.c
@@ -51,6 +51,14 @@ COMMAND_HANDLER(arc_handle_has_dcache)
 		&arc32->has_dcache, "target has data-cache");
 }
 
+COMMAND_HANDLER(arc_handle_has_l2cache)
+{
+	struct arc32_common *arc32 = target_to_arc32(
+		get_current_target(CMD_CTX));
+	return CALL_COMMAND_HANDLER(handle_command_parse_bool,
+		&arc32->has_l2cache, "target has l2 cache");
+}
+
 /* Add flags register data type */
 enum add_reg_type_flags {
 	CFG_ADD_REG_TYPE_FLAGS_NAME,
@@ -1097,6 +1105,13 @@ static const struct command_registration arc_core_command_handlers[] = {
 		.mode = COMMAND_ANY,
 		.usage = "True or false",
 		.help = "Does target has D$? If yes it will be flushed before memory reads.",
+	},
+	{
+		.name = "has-l2cache",
+		.handler = arc_handle_has_l2cache,
+		.mode = COMMAND_ANY,
+		.usage = "True or false",
+		.help = "Does target have L2$? If yes it will be flushed before memory reading."
 	},
 	{
 		.name = "add-reg-type-flags",

--- a/src/target/arc_regs.h
+++ b/src/target/arc_regs.h
@@ -61,6 +61,15 @@
 #define AUX_DC_CTRL_REG			0X48
 #define DC_CTRL_IM			(1 << 6)
 
+/* L2 cache registers */
+#define SLC_AUX_CACHE_CTRL 		0x903
+#define L2_CTRL_IM			(1 << 6)
+#define L2_CTRL_BS			(1 << 8)
+#define SLC_AUX_CACHE_FLUSH 		0x904
+#define L2_FLUSH_FL     		(1)
+#define SLC_AUX_CACHE_INV 		0x905
+#define L2_INV_IV       		(1)
+
 #define AUX_IENABLE_REG			0x40C
 #define SET_CORE_DISABLE_INTERRUPTS		0x00000000
 #define SET_CORE_ENABLE_INTERRUPTS		0xFFFFFFFF

--- a/tcl/board/snps_hsdk.cfg
+++ b/tcl/board/snps_hsdk.cfg
@@ -1,0 +1,36 @@
+#  Copyright (C) 2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# Synopsys DesignWare ARC AXS103 Software Development Platform (HS38 cores)
+#
+
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+source [find interface/ftdi/snps_sdp.cfg]
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_hsdk.cfg]
+
+# Initialize
+init
+reset halt
+

--- a/tcl/target/snps_hsdk.cfg
+++ b/tcl/target/snps_hsdk.cfg
@@ -44,6 +44,9 @@ set _coreid [expr $_coreid + 1]
 set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
+# Enable L2 cache support for core 4.
+$_TARGETNAME arc has-l2cache true
+
 # ARC HS38 core 3
 set _TARGETNAME $_CHIPNAME.cpu3
 jtag newtap $_CHIPNAME cpu3 -irlen 4 -ircapture 0x1 -expected-id 0x200824b1
@@ -55,6 +58,9 @@ $_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
 set _coreid [expr $_coreid + 1]
 set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
+
+# Enable L2 cache support for core 3.
+$_TARGETNAME arc has-l2cache true
 
 # ARC HS38 core 2
 set _TARGETNAME $_CHIPNAME.cpu2
@@ -68,6 +74,9 @@ set _coreid [expr $_coreid + 1]
 set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
 
+# Enable L2 cache support for core 2.
+$_TARGETNAME arc has-l2cache true
+
 # ARC HS38 core 1
 set _TARGETNAME $_CHIPNAME.cpu1
 jtag newtap $_CHIPNAME cpu1 -irlen 4 -ircapture 0x1 -expected-id 0x200024b1
@@ -79,3 +88,6 @@ $_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
 set _coreid [expr $_coreid + 1]
 set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
 arc_hs_init_regs
+
+# Enable L2 cache support for core 1.
+$_TARGETNAME arc has-l2cache true

--- a/tcl/target/snps_hsdk.cfg
+++ b/tcl/target/snps_hsdk.cfg
@@ -1,0 +1,81 @@
+#  Copyright (C) 2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# HS Development Kit SoC.
+#
+# Contains quad-core ARC HS38.
+#
+
+source [find cpu/arc/hs.tcl]
+
+set _coreid 0
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+# OpenOCD discovers JTAG TAPs in reverse order.
+
+# ARC HS38 core 4
+set _TARGETNAME $_CHIPNAME.cpu4
+jtag newtap $_CHIPNAME cpu4 -irlen 4 -ircapture 0x1 -expected-id 0x200c24b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME -rtos auto
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+# Flush L2$.
+$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# ARC HS38 core 3
+set _TARGETNAME $_CHIPNAME.cpu3
+jtag newtap $_CHIPNAME cpu3 -irlen 4 -ircapture 0x1 -expected-id 0x200824b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME -rtos auto
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# ARC HS38 core 2
+set _TARGETNAME $_CHIPNAME.cpu2
+jtag newtap $_CHIPNAME cpu2 -irlen 4 -ircapture 0x1 -expected-id 0x200424b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME -rtos auto
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# ARC HS38 core 1
+set _TARGETNAME $_CHIPNAME.cpu1
+jtag newtap $_CHIPNAME cpu1 -irlen 4 -ircapture 0x1 -expected-id 0x200024b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME -rtos auto
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs


### PR DESCRIPTION
This commit includes the initial support of ARCv2 HS Development Kit.
HSDK board was already supported in Zephyr so let's add one more
ARCv2 board, as everything is ready for this.
For more information about board see:
https://embarc.org/embarc_osp/doc/build/html/board/hsdk.html

Signed-off-by: Evgeniy Didin <didin@synopsys.com>