### PR TITLE
target/arc: introduce basic smp support

### DIFF
--- a/src/target/arc32.c
+++ b/src/target/arc32.c
@@ -389,7 +389,7 @@ int arc32_start_core(struct target *target)
 	CHECK_RETVAL(arc_jtag_read_aux_reg_one(&arc32->jtag_info, AUX_STATUS32_REG, &value));
 	value &= ~SET_CORE_HALT_BIT;        /* clear the HALT bit */
 	CHECK_RETVAL(arc_jtag_write_aux_reg_one(&arc32->jtag_info, AUX_STATUS32_REG, value));
-	LOG_DEBUG("Core started to run");
+	LOG_DEBUG("Core %s started to run", target_name(target));
 
 #ifdef DEBUG
 	CHECK_RETVAL(arc32_print_core_state(target));

--- a/src/target/arc32.h
+++ b/src/target/arc32.h
@@ -32,6 +32,7 @@
 #include "target.h"
 #include "target_request.h"
 #include "target_type.h"
+#include "smp.h"
 
 #include "arc_dbg.h"
 #include "arc_jtag.h"

--- a/src/target/arc_mntr.c
+++ b/src/target/arc_mntr.c
@@ -1046,6 +1046,44 @@ static int jim_handle_actionpoints_num(Jim_Interp *interp, int argc,
 	return JIM_OK;
 }
 
+COMMAND_HANDLER(arc_handle_smp_off_command)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	/* check target is an smp target */
+	struct target_list *head;
+	struct target *curr;
+	head = target->head;
+	target->smp = 0;
+	if (head != (struct target_list *)NULL) {
+		while (head != (struct target_list *)NULL) {
+			curr = head->target;
+			curr->smp = 0;
+			head = head->next;
+		}
+		/*  fixes the target display to the debugger */
+		target->gdb_service->target = target;
+	}
+	return ERROR_OK;
+}
+
+COMMAND_HANDLER(arc_handle_smp_on_command)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	struct target_list *head;
+	struct target *curr;
+	head = target->head;
+
+	if (head != (struct target_list *)NULL)	{
+		target->smp = 1;
+		while (head != (struct target_list *)NULL) {
+			curr = head->target;
+			curr->smp = 1;
+			head = head->next;
+		}
+	}
+	return ERROR_OK;
+}
+
 static const struct command_registration arc_jtag_command_group[] = {
 	{
 		.name = "always-check-status-rd",
@@ -1200,6 +1238,20 @@ static const struct command_registration arc_core_command_handlers[] = {
 		.mode = COMMAND_ANY,
 		.usage = "[<unsigned integer>]",
 		.help = "Prints or sets amount of actionpoints in the processor.",
+	},
+	{
+		.name = "smp_off",
+		.handler = arc_handle_smp_off_command,
+		.mode = COMMAND_EXEC,
+		.usage = "arc smp_off",
+		.help = "Stop smp handling",
+	},
+	{
+		.name = "smp_on",
+		.handler = arc_handle_smp_on_command,
+		.mode = COMMAND_EXEC,
+		.usage = "arc smp_on",
+		.help = "Restart smp handling",
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/tcl/board/snps_hsdk_smp.cfg
+++ b/tcl/board/snps_hsdk_smp.cfg
@@ -1,0 +1,36 @@
+#  Copyright (C) 2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# Synopsys DesignWare ARC AXS103 Software Development Platform (HS38 cores)
+#
+
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+source [find interface/ftdi/snps_sdp.cfg]
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_hsdk_smp.cfg]
+
+# Initialize
+init
+reset halt
+

--- a/tcl/target/snps_hsdk_smp.cfg
+++ b/tcl/target/snps_hsdk_smp.cfg
@@ -1,0 +1,95 @@
+#  Copyright (C) 2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# HS Development Kit SoC.
+#
+# Contains quad-core ARC HS38.
+#
+
+source [find cpu/arc/hs.tcl]
+
+set _coreid 0
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+# OpenOCD discovers JTAG TAPs in reverse order.
+
+# ARC HS38 core 4
+set _TARGETNAME $_CHIPNAME.cpu4
+jtag newtap $_CHIPNAME cpu4 -irlen 4 -ircapture 0x1 -expected-id 0x200c24b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+# Flush L2$.
+$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 4.
+$_TARGETNAME arc has-l2cache true
+
+# ARC HS38 core 3
+set _TARGETNAME1 $_CHIPNAME.cpu3
+jtag newtap $_CHIPNAME cpu3 -irlen 4 -ircapture 0x1 -expected-id 0x200824b1
+
+target create $_TARGETNAME1 arcv2 -chain-position $_TARGETNAME1
+$_TARGETNAME1 configure -coreid $_coreid
+$_TARGETNAME1 configure -dbgbase $_dbgbase
+$_TARGETNAME1 configure -event reset-assert "arc_common_reset $_TARGETNAME1"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 3.
+$_TARGETNAME1 arc has-l2cache true
+
+# ARC HS38 core 2
+set _TARGETNAME2 $_CHIPNAME.cpu2
+jtag newtap $_CHIPNAME cpu2 -irlen 4 -ircapture 0x1 -expected-id 0x200424b1
+
+target create $_TARGETNAME2 arcv2 -chain-position $_TARGETNAME2
+$_TARGETNAME2 configure -coreid $_coreid
+$_TARGETNAME2 configure -dbgbase $_dbgbase
+$_TARGETNAME2 configure -event reset-assert "arc_common_reset $_TARGETNAME2"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 2.
+$_TARGETNAME2 arc has-l2cache true
+
+# ARC HS38 core 1
+set _TARGETNAME3 $_CHIPNAME.cpu1
+jtag newtap $_CHIPNAME cpu1 -irlen 4 -ircapture 0x1 -expected-id 0x200024b1
+
+target create $_TARGETNAME3 arcv2 -chain-position $_TARGETNAME3
+$_TARGETNAME3 configure -coreid $_coreid
+$_TARGETNAME3 configure -dbgbase $_dbgbase
+$_TARGETNAME3 configure -event reset-assert "arc_common_reset $_TARGETNAME3"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 1.
+$_TARGETNAME3 arc has-l2cache true
+
+target smp $_CHIPNAME.cpu4 $_CHIPNAME.cpu3 $_CHIPNAME.cpu2 $_CHIPNAME.cpu1


### PR DESCRIPTION
With this commit we introduce basic SMP support for ARC targets.
Only running smp application in telnet is supported, GDB is
not supported yet.

SMP support starts with running "smp target1 target2..." command
during target initialization. This command creates linked list
of targets and sets for each ->smp=1. Next running poll()
function if one core is halted, it is necessary to poll
other cores in list. And finally resuming execution it is necessary
to restore context on each target and run each core.

Major changes in this commit:
 * Add "arc_smp on/of" handlers.
 * Modify resume, poll functions to process slave cores.
 * Introduced  arc_dbg_set_pc() and arc_ocd_poll_smp() functions
 * Introduced target/board snps_hsdk_smp.cfg files.

Usage via telnet:
 > load /path/to/bin
 > resume <start_address>

Signed-off-by: Evgeniy Didin <didin@synopsys.com>