### PR TITLE
stm32h723Xg SoC Support

### DIFF
--- a/src/flash/nor/stm32h7x.c
+++ b/src/flash/nor/stm32h7x.c
@@ -824,6 +824,12 @@ static int stm32x_probe(struct flash_bank *bank)
 			flash_size_in_kb /= 2;
 		break;
 	case 0x483:
+		/* For STM32H72x/73x
+		 *  - STM32H7xxxG devices contains single bank, 1024 Kbyte
+		 */
+		if (flash_size_in_kb == 128) {
+			has_dual_bank = false;
+		}
 		break;
 	default:
 		LOG_ERROR("unsupported device");


### PR DESCRIPTION
Dear all. I know, that this is not a primer OpenOCD dev repo. But I can't manage commiting my changes to original repor. Thereofre I am putting it here. This changes working for me with my nucle_h723zg board an allows me running compiled Zephyr RTOS Hello World sample.

How to compile:
```
./bootstrap
./configure --enable-shared --disable-internal-jimtcl
make
sudo make install
```

additionaly you may need to remove compiled files:
```
make clean
```

@galak Maybe my changes could help you adding h723 support to original OpenOCD repo. I give you also my permisssion for use this code usage in original OpenOCD repo under your name.

P.S.: I am not familiar with OpenOCD development procedure and wondering why this PR changes so much files. Originally I've made changes only to `src/flash/nor/stm32h7x.c` file upon the current master branch!