### PR TITLE
jlink: Support choosing a jlink serial number through west

### DIFF
--- a/tcl/interface/jlink.cfg
+++ b/tcl/interface/jlink.cfg
@@ -12,3 +12,8 @@ adapter driver jlink
 # Example: Select J-Link with serial number 123456789
 #
 # jlink serial 123456789
+
+if { [info exists _ZEPHYR_BOARD_SERIAL] } {
+   jlink serial $_ZEPHYR_BOARD_SERIAL
+}
+


### PR DESCRIPTION
When multiple devices using a jlink interface are connected
to the same host, trying to flash or debug them with west
fails, as openocd can't infer which of the devices to act on.
This PR enables west to explicitly choose a device using it's
serial number, e.g. `west flash --serial 123456789`

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>