### PR TITLE
cfg: Set STM32F746G discovery board to use 4000 kHz on reset-start

### DIFF
--- a/tcl/board/stm32f746g-disco.cfg
+++ b/tcl/board/stm32f746g-disco.cfg
@@ -67,3 +67,8 @@ $_TARGETNAME configure -event reset-init {
 
 	qspi_init
 }
+
+$_TARGETNAME configure -event reset-start {
+        adapter speed 4000
+
+}


### PR DESCRIPTION
Hi,

Could I get reviews for the following change that affects only ST STM32F746G Discovery boards, please?

Currently board/stm32f746g-disco.cfg already uses the maximum adapter speed
available for reset-init events (4000 kHz). However it doesn't set that
speed for reset-start events and so the speed for that event is inherited
from the included config file arget/stm32f7x.cfg, which sets that speed to
just 2000 kHz.

That commit overrides the inherited speed for reset-start events setting
the adapter speed to be equal to the one used for reset-init events, i.e.
to its maximum speed (4000 kHz).

That change avoids the following messages to appear when fashing the
board:

```
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
```

Like, for instance, in:
```
Open On-Chip Debugger 0.10.0+dev-01508-gf79c90268-dirty (2021-01-14-14:40)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
066CFF485153826687133653
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.236292
Warn : Silicon bug: single stepping may enter pending exception handler!
Info : stm32f7x.cpu: hardware has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f7x.cpu on 3333
Info : Listening on port 3333 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       running

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08001fb0 msp: 0x200331a8
Info : device id = 0x10016449
Info : flash size = 1024 kbytes
auto erase enabled
wrote 32768 bytes from file /tmp/tvm-debug-mode-tempdirs/2021-01-15T17-48-42___qjv395d0/00000/build/runtime/zephyr/zephyr.hex in 1.377706s (23.227 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08001fb0 msp: 0x200331a8
verified 32108 bytes in 0.455013s (68.911 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
```
It also increases the throughput a bit when flashing the device.

Thanks,
Gustavo