### PR TITLE
tfc/target: stm32: Fix missing DBG clock on stm32g0/l0

### DIFF
--- a/tcl/target/stm32g0x.cfg
+++ b/tcl/target/stm32g0x.cfg
@@ -63,6 +63,10 @@ proc stm32g0x_default_reset_start {} {
 }
 
 proc stm32g0x_default_examine_end {} {
+	# Enable DBG clock
+	# RCC_APB1ENR |= DBGEN
+	mmw 0x4002103C 0x08000000 0
+
 	# DBGMCU_CR |= DBG_STANDBY | DBG_STOP
 	mmw 0x40015804 0x00000006 0
 

--- a/tcl/target/stm32l0.cfg
+++ b/tcl/target/stm32l0.cfg
@@ -82,6 +82,10 @@ $_TARGETNAME configure -event reset-start {
 }
 
 $_TARGETNAME configure -event examine-end {
+	# Enable DBG clock
+	# RCC_APB2ENR |= DBGMCUEN
+	mmw 0x40001024 0x00400000 0
+
 	# DBGMCU_CR |= DBG_STANDBY | DBG_STOP | DBG_SLEEP
 	mmw 0x40015804 0x00000007 0
 


### PR DESCRIPTION
On stm32g0 and stm32l0 series, DGCMCU clock should be enabled
before any access.
This was missing, fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>