### PR TITLE
target/arc: implement dummy checksum_memory()

### DIFF
--- a/src/target/arc.c
+++ b/src/target/arc.c
@@ -2475,6 +2475,14 @@ int arc_cache_flush(struct target *target)
 	return ERROR_OK;
 }
 
+static int arc_checksum_memory(struct target *target,
+		target_addr_t address, uint32_t count,
+		uint32_t *checksum)
+{
+	/* Return non ERROR_OK to trigger real host-side memory read-back */
+	return ERROR_FAIL;
+}
+
 /* ARC v2 target */
 struct target_type arcv2_target = {
 	.name = "arcv2",
@@ -2501,7 +2509,7 @@ struct target_type arcv2_target = {
 
 	.read_memory = arc_mem_read,
 	.write_memory = arc_mem_write,
-	.checksum_memory = NULL,
+	.checksum_memory = arc_checksum_memory,
 	.blank_check_memory = NULL,
 
 	.add_breakpoint = arc_add_breakpoint,


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/pull/35284 it was found that use of `verify_image` command for ARC boards lead to OpenOCD segfault:
```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000455e27 in target_checksum_memory (target=target@entry=0xa52450, address=2415919104, size=19952, crc=crc@entry=0x7fffffffcf64) at src/target/target.c:2522
#2  0x0000000000456066 in handle_verify_image_command_internal (cmd=0x7fffffffd040, verify=IMAGE_VERIFY) at src/target/target.c:3846
#3  0x000000000047e4ca in run_command (num_words=2, words=0xa80800, c=0x9f3ea0, context=0x9a7010) at src/helper/command.c:582
#4  exec_command (argv=0x7fffffffd140, argc=<optimized out>, c=0x9f3ea0, cmd_ctx=0x9a7010, interp=0x9a7070) at src/helper/command.c:950
#5  jim_command_dispatch (interp=0x9a7070, argc=<optimized out>, argv=0x7fffffffd140) at src/helper/command.c:1001
#6  0x00000000005b839a in JimInvokeCommand (interp=interp@entry=0x9a7070, objc=objc@entry=2, objv=objv@entry=0x7fffffffd140) at jim.c:10514
#7  0x00000000005b8fbc in Jim_EvalObj (interp=interp@entry=0x9a7070, scriptObjPtr=scriptObjPtr@entry=0x9e96d0) at jim.c:11006
#8  0x00000000005bb12b in Jim_EvalSource (interp=interp@entry=0x9a7070, filename=filename@entry=0x0, lineno=lineno@entry=0,
    script=script@entry=0x9e0db0 "verify_image build/zephyr/zephyr.elf") at jim.c:11298
#9  0x000000000047df5f in command_run_line (context=context@entry=0x9a7010, line=0x9e0db0 "verify_image build/zephyr/zephyr.elf") at src/helper/command.c:626
#10 0x000000000047f6b8 in parse_config_file (cmd_ctx=cmd_ctx@entry=0x9a7010) at src/helper/configuration.c:136
#11 0x00000000004053ae in openocd_thread (cmd_ctx=0x9a7010, argv=0x7fffffffd378, argc=18) at src/openocd.c:296
#12 openocd_main (argc=18, argv=0x7fffffffd378) at src/openocd.c:356
#13 0x00007ffff710d505 in __libc_start_main () from /lib64/libc.so.6
#14 0x0000000000404e9e in _start ()
```

That happens because we used to have ".checksum_memory" undefined for ARC. And it was undefined on purpose as we never got to implement a target-executed applet for CRC calculation.

But there seems to be a work-around of using real memory read back via JTAG. And for that we just need to return anything != `ERROR_OK` from `.checksum_memory()` callback. Which we do here.

Now image verification works for ARC as well!