### PR TITLE
openocd: target: changing the order of the JTAG devices

### DIFF
--- a/tcl/target/altera_fpgasoc.cfg
+++ b/tcl/target/altera_fpgasoc.cfg
@@ -7,6 +7,14 @@ if { [info exists CHIPNAME] } {
    set _CHIPNAME fpgasoc
 }
 
+# Subsidiary TAP: fpga
+if { [info exists FPGA_TAPID] } {
+   set _FPGA_TAPID $FPGA_TAPID
+} else {
+   set _FPGA_TAPID 0x02d020dd
+}
+jtag newtap $_CHIPNAME.fpga tap -irlen 10 -ircapture 0x01 -irmask 0x3 -expected-id $_FPGA_TAPID
+
 # CoreSight Debug Access Port
 if { [info exists DAP_TAPID] } {
         set _DAP_TAPID $DAP_TAPID
@@ -16,16 +24,6 @@ if { [info exists DAP_TAPID] } {
 
 jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x01 -irmask 0x0f \
         -expected-id $_DAP_TAPID
-
-# Subsidiary TAP: fpga
-if { [info exists FPGA_TAPID] } {
-   set _FPGA_TAPID $FPGA_TAPID
-} else {
-   set _FPGA_TAPID 0x02d020dd
-}
-jtag newtap $_CHIPNAME.fpga tap -irlen 10 -ircapture 0x01 -irmask 0x3 -expected-id $_FPGA_TAPID
-
-
 #
 # Cortex-A9 target
 #


### PR DESCRIPTION
For Cyclone V SoC Development kit, the order of the JTAG devices is
inverted when using USB blaster to program the SoC, this is a fix,
so the user dont have to do it manually

Signed-off-by: Esteban Valverde <esteban.valverde.vega@intel.com>