### PR TITLE
Revert "target: reset target examined flag if target::examine() fails"

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -733,15 +733,6 @@ static int no_mmu(struct target *target, int *enabled)
 	return ERROR_OK;
 }
 
-/**
- * Reset the @c examined flag for the given target.
- * Pure paranoia -- targets are zeroed on allocation.
- */
-static inline void target_reset_examined(struct target *target)
-{
-	target->examined = false;
-}
-
 static int default_examine(struct target *target)
 {
 	target_set_examined(target);
@@ -762,12 +753,10 @@ int target_examine_one(struct target *target)
 
 	int retval = target->type->examine(target);
 	if (retval != ERROR_OK) {
-		target_reset_examined(target);
 		target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_FAIL);
 		return retval;
 	}
 
-	target_set_examined(target);
 	target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_END);
 
 	return ERROR_OK;
@@ -1547,6 +1536,15 @@ static int target_profiling(struct target *target, uint32_t *samples,
 {
 	return target->type->profiling(target, samples, max_num_samples,
 			num_samples, seconds);
+}
+
+/**
+ * Reset the @c examined flag for the given target.
+ * Pure paranoia -- targets are zeroed on allocation.
+ */
+static void target_reset_examined(struct target *target)
+{
+	target->examined = false;
 }
 
 static int handle_target(void *priv);
@@ -3080,7 +3078,7 @@ static int handle_target(void *priv)
 				/* Target examination could have failed due to unstable connection,
 				 * but we set the examined flag anyway to repoll it later */
 				if (retval != ERROR_OK) {
-					target_set_examined(target);
+					target->examined = true;
 					LOG_USER("Examination failed, GDB will be halted. Polling again in %dms",
 						 target->backoff.times * polling_interval);
 					return retval;
@@ -5742,13 +5740,8 @@ static int jim_target_examine(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 	}
 
 	int e = target->type->examine(target);
-	if (e != ERROR_OK) {
-		target_reset_examined(target);
+	if (e != ERROR_OK)
 		return JIM_ERR;
-	}
-
-	target_set_examined(target);
-
 	return JIM_OK;
 }
 


### PR DESCRIPTION
This reverts commit 98d9f1168cbdc59e4c2c0b1f01b225a4df9ad98a because it causes flashing issues with some Zephyr targets (notably, STM32 family devices).

The patch in itself does not seem to be doing anything wrong in particular; but, it uncovers various problems with the Zephyr-side OpenOCD configurations -- mainly, not resetting the target device on debugger connect, which may lead to connection failures because Zephyr puts the target CPU to sleep while idling and the CPU cannot respond to the debugger's request in this state.

For more details, refer to the GitHub issue
zephyrproject-rtos/zephyr#50590.

Revert this commit once the Zephyr-side OpenOCD configurations are fixed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>