### PR TITLE
github/workflow: increase delete-tag-and-release version

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,7 +8,7 @@ name: OpenOCD Snapshot
 
 jobs:
   package:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     env:
       DL_DIR: ../downloads
       BUILD_DIR: ../build
@@ -30,7 +30,7 @@ jobs:
           echo "LIBUSB1_SRC=$PWD/libusb-${LIBUSB1_VER}" >> $GITHUB_ENV
       - name: Prepare hidapi
         env:
-          HIDAPI_VER: 0.11.2
+          HIDAPI_VER: 0.13.1
         run: |
           mkdir -p $DL_DIR && cd $DL_DIR
           wget "https://github.com/libusb/hidapi/archive/hidapi-${HIDAPI_VER}.tar.gz"
@@ -82,6 +82,7 @@ jobs:
           # add missing dlls
           cd $HOST-root/usr
           cp `$HOST-gcc --print-file-name=libwinpthread-1.dll` ./bin/
+          # required by libftdi1.dll. For the gcc-mingw-10.3.x or later "libgcc_s_dw2-1.dll" will need to be copied.
           cp `$HOST-gcc --print-file-name=libgcc_s_sjlj-1.dll` ./bin/
           # prepare the artifact
           ARTIFACT="openocd-${OPENOCD_TAG}-${HOST}.tar.gz"
@@ -90,11 +91,11 @@ jobs:
           echo "IS_PRE_RELEASE=$IS_PRE_RELEASE" >> $GITHUB_ENV
           echo "ARTIFACT_PATH=$PWD/$ARTIFACT" >> $GITHUB_ENV
       - name: Publish OpenOCD packaged for windows
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.ARTIFACT_PATH }}
       - name: Delete 'latest' Release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           delete_release: true
           tag_name: ${{ env.RELEASE_NAME }}


### PR DESCRIPTION
During setup job in the GH actions, GH tries to resolve all actions before starting to run the scripts.
It can not find 0.2.0 version inside
'dev-drprasad/delete-tag-and-release 'repo and action fails.

This patch fixes that error.
Also, switched to the latest ubuntu image
Hidapi version updated to 0.13.1


Change-Id: I02af41f6189d5a28f874c9b008073d74de46b4ca Reviewed-on: https://review.openocd.org/c/openocd/+/7551 Tested-by: jenkins
Reviewed-by: Antonio Borneo <borneo.antonio@gmail.com>
(cherry picked from commit 4b9b55a832e43815a1dd1b219107a01a1beadc1e)