### PR TITLE
target/arc + risc-v: add RTT commands

### DIFF
--- a/src/target/arc.h
+++ b/src/target/arc.h
@@ -23,6 +23,7 @@
 #include "target_type.h"
 #include "helper/bits.h"
 #include "smp.h"
+#include "rtt/rtt.h"
 
 #include "arc_jtag.h"
 #include "arc_cmd.h"

--- a/src/target/arc_cmd.c
+++ b/src/target/arc_cmd.c
@@ -1086,5 +1086,8 @@ const struct command_registration arc_monitor_command_handlers[] = {
 		.usage = "",
 		.chain = arc_core_command_handlers,
 	},
+	{
+		.chain = rtt_target_command_handlers,
+	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -22,6 +22,7 @@
 #include "rtos/rtos.h"
 #include "debug_defines.h"
 #include <helper/bits.h>
+#include <rtt/rtt.h>
 
 #define get_field(reg, mask) (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
 #define set_field(reg, mask, val) (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
@@ -3130,6 +3131,9 @@ const struct command_registration riscv_command_handlers[] = {
 		.help = "ARM Command Group",
 		.usage = "",
 		.chain = semihosting_common_handlers
+	},
+	{
+		.chain = rtt_target_command_handlers,
 	},
 	COMMAND_REGISTRATION_DONE
 };


### PR DESCRIPTION
From https://review.openocd.org/c/openocd/+/8234

> The original patch to add the SEGGER RTT tooling added it only for ARM devices. But now JLink supports RISC-V targets and we can now add the RTT command domain to the RISC-V target. I've tested this on my RISC-V 32-bit chip and it appears to be working - I was able to communicate with the device using the RTT.

Additionally, add support for the ARC architecture, since RTT itself is architecture agnostic.

Tested on custom silicon.