### PR TITLE
Add support for Microchip Polarfire SoC, PIC64GX and Embedded Flashpro 5

### DIFF
--- a/contrib/60-openocd.rules
+++ b/contrib/60-openocd.rules
@@ -167,6 +167,10 @@ ATTRS{idVendor}=="138e", ATTRS{idProduct}=="9000", MODE="660", GROUP="plugdev", 
 # Debug Board for Neo1973
 ATTRS{idVendor}=="1457", ATTRS{idProduct}=="5118", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
+# Microchip RISC-V Debug
+ATTRS{idVendor}=="1514", ATTRS{idProduct}=="2008", MODE="660", GROUP="plugdev", TAG+="uaccess"
+ATTRS{idVendor}=="1514", ATTRS{idProduct}=="200a", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
 # OSBDM
 ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0042", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0058", MODE="660", GROUP="plugdev", TAG+="uaccess"

--- a/tcl/board/microchip/pic64gx-curiosity-kit.cfg
+++ b/tcl/board/microchip/pic64gx-curiosity-kit.cfg
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Microchip RISC-V board
+#
+# https://www.microchip.com/en-us/products/microprocessors/64-bit-mpus/pic64gx
+#
+adapter speed 6000
+
+source [find interface/microchip/embedded_flashpro5.cfg]
+source [find target/microchip/pic64gx.cfg]

--- a/tcl/interface/microchip/embedded_flashpro5.cfg
+++ b/tcl/interface/microchip/embedded_flashpro5.cfg
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Embedded FlashPro5
+#
+# https://www.microchip.com/en-us/development-tool/flashpro5
+#
+
+adapter driver ftdi
+
+# vidpid 1514:2008 = embedded flashpro5
+# vidpid 1514:200a = pic64gx
+ftdi vid_pid 0x1514 0x2008 0x1514 0x200a
+
+# That FTDI has 4 channels (channel 0 and 1 are MPSSE-capable, 2 and 3 are bitbang
+ftdi channel 0
+
+# Initial Layout - data[0..15] direction[0..15]
+ftdi layout_init 0x0018 0xfdfb
+#     Signal        Data    Direction       Notes
+# AD0 TCK           0       1 (out)         Port A TCK
+# AD1 TDI           0       1 (out)         Port A TDI
+# AD2 TDO           0       0 (in)          PORT A TDO
+# AD3 TMS           1       1 (out)         Port A TMS
+# AD4 GPIOL0        1       1 (out)         Port A TRST
+# AD5 GPIOL1        0       1 (out)         (unused)
+# AD6 GPIOL2        0       1 (out)         (unused)
+# AD7 GPIOL3        0       1 (out)         (unused)
+
+# BD0 TCK           0       1 (out)         FTDI_UART_B_TXD
+# BD1 TDI           0       0 (in)          FTDI_UART_B_RXD
+# BD2 TDO           0       1 (out)         (unused)
+# BD3 TMS           0       1 (out)         (unused)
+# BD4 GPIOL0        0       1 (out)         (unused)
+# BD5 GPIOL1        0       1 (out)         (unused)
+# BD6 GPIOL2        0       1 (out)         (unused)
+# BD7 GPIOL2        0       1 (out)         (unused)
+
+# Signals definition
+ftdi layout_signal nTRST -data 0x0010 -oe 0x0010

--- a/tcl/target/microchip/mpfs.cfg
+++ b/tcl/target/microchip/mpfs.cfg
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Target: MPFS PolarFire SoC-series processors by Microchip Technologies
+#
+# https://www.microchip.com/en-us/products/fpgas-and-plds/system-on-chip-fpgas/polarfire-soc-fpgas
+#
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME mpfs
+}
+
+# Process COREID variable
+if { ![exists COREID] } {
+	set COREID -1
+}
+
+transport select jtag
+
+# PolarFire SoC (MPFS) hart id to name lookup table
+array set hart_names {
+	0	e51
+	1	u54_1
+	2	u54_2
+	3	u54_3
+	4	u54_4
+}
+
+# MPFS devices table
+set mpfs_cpu_tap_info {
+	MPFS025  0x0f8531cf
+	MPFS095  0x0f8181cf
+	MPFS160  0x0f8191cf
+	MPFS250  0x0f81a1cf
+	MPFS460  0x0f81b1cf
+	RTPFS160 0x0f8991cf
+	RTPFS460 0x0f89b1cf
+}
+
+proc expected_ids {tap_list} {
+	set str ""
+	dict for {key value} $tap_list {
+		append str "-expected-id" " " $value " "
+	}
+
+	return $str
+}
+
+set irlen 8
+set expected_ids [expected_ids $mpfs_cpu_tap_info]
+eval jtag newtap $_CHIPNAME cpu -irlen $irlen $expected_ids -ignore-version
+
+if {$COREID == -1} {
+	# Single debug connection to all HART's
+	set _TARGETNAME_0 $_CHIPNAME.$hart_names(0)
+	set _TARGETNAME_1 $_CHIPNAME.$hart_names(1)
+	set _TARGETNAME_2 $_CHIPNAME.$hart_names(2)
+	set _TARGETNAME_3 $_CHIPNAME.$hart_names(3)
+	set _TARGETNAME_4 $_CHIPNAME.$hart_names(4)
+
+	target create $_TARGETNAME_0 riscv -chain-position $_CHIPNAME.cpu -coreid 0 -rtos hwthread
+	target create $_TARGETNAME_1 riscv -chain-position $_CHIPNAME.cpu -coreid 1 -rtos hwthread
+	target create $_TARGETNAME_2 riscv -chain-position $_CHIPNAME.cpu -coreid 2 -rtos hwthread
+	target create $_TARGETNAME_3 riscv -chain-position $_CHIPNAME.cpu -coreid 3 -rtos hwthread
+	target create $_TARGETNAME_4 riscv -chain-position $_CHIPNAME.cpu -coreid 4 -rtos hwthread
+	target smp $_TARGETNAME_0 $_TARGETNAME_1 $_TARGETNAME_2 $_TARGETNAME_3 $_TARGETNAME_4
+} else {
+	# Debug connection to a specific hart
+	set _TARGETNAME_0 $_CHIPNAME.$hart_names($COREID)
+	target create $_TARGETNAME_0 riscv -chain-position $_CHIPNAME.cpu -coreid $COREID
+}
+
+# Only TRSTn supported
+reset_config trst_only

--- a/tcl/target/microchip/pic64gx.cfg
+++ b/tcl/target/microchip/pic64gx.cfg
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Target: Pic64gx processor by Microchip Technologies
+#
+# https://www.microchip.com/en-us/products/microprocessors/64-bit-mpus/pic64gx
+#
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME pic64gx
+}
+
+# Process COREID variable
+if {![exists COREID]} {
+	set COREID -1
+}
+
+transport select jtag
+
+# PIC64GX hart id to name lookup table
+array set hart_names {
+	0	e51
+	1	u54_1
+	2	u54_2
+	3	u54_3
+	4	u54_4
+}
+
+# PIC64GX table
+set pic64gx_tap_info {
+	PIC64GX1000 0x0f8531cf
+}
+
+proc expected_ids {tap_list} {
+	set str ""
+	dict for {key value} $tap_list {
+		append str "-expected-id" " " $value " "
+	}
+
+	return $str
+}
+
+set irlen 8
+set expected_ids [expected_ids $pic64gx_tap_info]
+eval jtag newtap $_CHIPNAME cpu -irlen $irlen $expected_ids -ignore-version
+
+if {$COREID == -1} {
+	# Single debug connection to all harts
+	set _TARGETNAME_0 $_CHIPNAME.$hart_names(0)
+	set _TARGETNAME_1 $_CHIPNAME.$hart_names(1)
+	set _TARGETNAME_2 $_CHIPNAME.$hart_names(2)
+	set _TARGETNAME_3 $_CHIPNAME.$hart_names(3)
+	set _TARGETNAME_4 $_CHIPNAME.$hart_names(4)
+
+	target create $_TARGETNAME_0 riscv -chain-position $_CHIPNAME.cpu -coreid 0 -rtos hwthread
+	target create $_TARGETNAME_1 riscv -chain-position $_CHIPNAME.cpu -coreid 1 -rtos hwthread
+	target create $_TARGETNAME_2 riscv -chain-position $_CHIPNAME.cpu -coreid 2 -rtos hwthread
+	target create $_TARGETNAME_3 riscv -chain-position $_CHIPNAME.cpu -coreid 3 -rtos hwthread
+	target create $_TARGETNAME_4 riscv -chain-position $_CHIPNAME.cpu -coreid 4 -rtos hwthread
+	target smp $_TARGETNAME_0 $_TARGETNAME_1 $_TARGETNAME_2 $_TARGETNAME_3 $_TARGETNAME_4
+} else {
+	# Debug connection to a specific hart
+	set _TARGETNAME_0 $_CHIPNAME.$hart_names($COREID)
+	target create $_TARGETNAME_0 riscv -chain-position $_CHIPNAME.cpu -coreid $COREID
+}
+
+# Only TRSTn supported
+reset_config trst_only


### PR DESCRIPTION
These 3 commits:

1. Adds basic target and board support for the PIC64GX and PIC64GX Curiosity
2. Adds interface support for the Embedded Flashpro5
3. Adds target support of Microchip Polarfire SoC (MPFS)