### PR TITLE
Add support for Bouffalo Lab chips based on upstreamed commits

### DIFF
--- a/tcl/target/bl602.cfg
+++ b/tcl/target/bl602.cfg
@@ -1,27 +1,27 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 #
-# Bouffalo Labs BL702, BL704 and BL706 target
+# Bouffalo Labs BL602 and BL604 target
 #
-# https://en.bouffalolab.com/product/?type=detail&id=8
+# https://en.bouffalolab.com/product/?type=detail&id=1
 #
 # Default JTAG pins: (if not changed by eFuse configuration)
-# TMS - GPIO0
-# TDI - GPIO1
-# TCK - GPIO2
-# TDO - GPIO9
+# TDO - GPIO11
+# TMS - GPIO12
+# TCK - GPIO14
+# TDI - GPIO17
 #
 
 if { [info exists CHIPNAME] } {
 	set BL602_CHIPNAME $CHIPNAME
 } else {
-	set BL602_CHIPNAME bl702
+	set BL602_CHIPNAME bl602
 }
 
-set CPUTAPID 0x20000e05
+set CPUTAPID 0x20000c05
 
 # For work-area we use DTCM instead of ITCM, due ITCM is used as buffer for L1 cache and XIP
-set WORKAREAADDR 0x22014000
+set WORKAREAADDR 0x42014000
 set WORKAREASIZE 0xC000
 
 source [find target/bl602_common.cfg]

--- a/tcl/target/bl602_common.cfg
+++ b/tcl/target/bl602_common.cfg
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Script for Bouffalo chips with similar architecture used in BL602
+# based on SiFive E21 core
+
+source [find mem_helper.tcl]
+
+transport select jtag
+
+if { [info exists CPUTAPID ] } {
+	set _CPUTAPID $CPUTAPID
+} else {
+	error "you must specify a tap id"
+}
+
+if { [info exists BL602_CHIPNAME] } {
+	set _CHIPNAME $BL602_CHIPNAME
+} else {
+	error "you must specify a chip name"
+}
+
+if { [info exists WORKAREAADDR] } {
+	set _WORKAREAADDR $WORKAREAADDR
+} else {
+	error "you must specify a work area address"
+}
+
+if { [info exists WORKAREASIZE] } {
+	set _WORKAREASIZE $WORKAREASIZE
+} else {
+	error "you must specify a work area size"
+}
+
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id $_CPUTAPID
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+riscv set_mem_access sysbus
+riscv set_enable_virt2phys off
+
+$_TARGETNAME configure -work-area-phys $_WORKAREAADDR -work-area-size $_WORKAREASIZE -work-area-backup 1
+
+# Internal RC ticks on 32 MHz, so this speed should be safe to use.
+adapter speed 8000
+
+# Useful functions
+
+set dmcontrol 		0x10
+set dmcontrol_dmactive	[expr {1 << 0}]
+set dmcontrol_ndmreset	[expr {1 << 1}]
+set dmcontrol_resumereq	[expr {1 << 30}]
+set dmcontrol_haltreq	[expr {1 << 31}]
+
+proc bl602_restore_clock_defaults { } {
+	# Switch clock to internal RC32M
+	# In HBN_GLB, set ROOT_CLK_SEL = 0
+	mmw 0x4000f030 0x0 0x00000003
+	# Wait for clock switch
+	sleep 10
+
+	# GLB_REG_BCLK_DIS_FALSE
+	mww 0x40000ffc 0x0
+
+	# HCLK is RC32M, so BCLK/HCLK doesn't need divider
+	# In GLB_CLK_CFG0, set BCLK_DIV = 0 and HCLK_DIV = 0
+	mmw 0x40000000 0x0 0x00FFFF00
+	# Wait for clock to stabilize
+	sleep 10
+}
+
+# By spec, ndmreset should reset whole chip. This implementation resets only few parts of the chip.
+# CTRL_PWRON_RESET register in GLB core triggers full "power-on like" reset, so we use it instead
+# for full software reset.
+proc bl602_sw_reset { } {
+	# In GLB_SWRST_CFG2, clear CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET
+	mmw 0x40000018 0x0 0x00000007
+
+	# This Software reset method resets everything, so CPU as well.
+	# It does that in not much good way, resulting in Debug Module being reset as well.
+	# This also means, that right after CPU and Debug Module are turned on, we need to
+	# enable Debug Module and halt CPU if needed. Additionally, we trigger this SW reset
+	# through system bus access directly with DMI commands, to avoid errors printed by
+	# OpenOCD about unsuccessful register write.
+
+	# In GLB_SWRST_CFG2, set CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET to 1
+	riscv dmi_write 0x39 0x40000018
+	riscv dmi_write 0x3c 0x7
+
+	# We need to wait for chip to finish reset and execute BootROM
+	sleep 1
+
+	# JTAG Debug Transport Module is reset as well, so we need to get into RUN/IDLE state
+	runtest 10
+
+	# We need to enable Debug Module and halt the CPU, so we can reset Program Counter
+	# and to do additional clean-ups. If reset was called without halt, resume is handled
+	# by reset-deassert-post event handler.
+
+	# In Debug Module Control (dmcontrol), set dmactive to 1 and then haltreq to 1
+	riscv dmi_write $::dmcontrol $::dmcontrol_dmactive
+	riscv dmi_write $::dmcontrol [ expr {$::dmcontrol_dmactive | $::dmcontrol_haltreq} ]
+
+	# Set Program Counter to start of BootROM
+	set_reg {pc 0x21000000}
+}
+
+# On BL602 and BL702, the only way to force chip stay in BootROM (until JTAG attaches)
+# is by putting infinity loop into HBN RAM (which is not reset by sw reset), and then
+# configure HBN registers, which will cause BootROM to jump into our code early in BootROM.
+proc bl602_sw_reset_hbn_wait {} {
+	# Restore clocks to defaults
+	bl602_restore_clock_defaults
+
+	# In HBN RAM, write infinity loop instruction
+	# beq zero, zero, 0
+	mww 0x40010000 0x00000063
+	# In HNB, set HBN_RSV0 (Status Flag) to "EHBN" (as uint32_t)
+	mww 0x4000f100 0x4e424845
+	# In HBN, set HBN_RSV1 (WakeUp Address) to HBN RAM address
+	mww 0x4000f104 0x40010000
+
+	# Perform software reset
+	bl602_sw_reset
+
+	# Clear HBN RAM, HBN_RSV0 and HBN_RSV1
+	mww 0x40010000 0x00000000
+	mww 0x4000f100 0x00000000
+	mww 0x4000f104 0x00000000
+
+	# This early jump method locks up BootROM through Trust Zone Controller.
+	# That means any read of BootROM returns 0xDEADBEEF.
+	# Only way to reset it, is through JTAG Reset, thus toggling ndmreset in dmcontrol.
+	riscv dmi_write $::dmcontrol [ expr {$::dmcontrol_dmactive | $::dmcontrol_ndmreset} ]
+	riscv dmi_write $::dmcontrol [ expr {$::dmcontrol_dmactive} ]
+}
+
+$_TARGETNAME configure -event reset-deassert-post {
+	# Resume the processor if reset was triggered without halt request
+	if {$halt == 0} {
+		riscv dmi_write $::dmcontrol [ expr {$::dmcontrol_dmactive | $::dmcontrol_resumereq} ]
+	}
+}

--- a/tcl/target/bl616.cfg
+++ b/tcl/target/bl616.cfg
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Author: Marek Kraus <gamelaster@gami.ee>
+
+#
+# Bouffalo Labs BL616 and BL618 target
+#
+# Default JTAG pins: (if not changed by eFuse configuration)
+# TMS - GPIO0
+# TCK - GPIO1
+# TDO - GPIO2
+# TDI - GPIO3
+#
+
+source [find mem_helper.tcl]
+
+transport select jtag
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME bl616
+}
+
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10000b6f
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+riscv set_mem_access progbuf
+riscv set_enable_virt2phys off
+
+$_TARGETNAME configure -work-area-phys 0x40000000 -work-area-size 0x10000 -work-area-backup 1
+
+adapter speed 4000
+
+# Useful functions
+set dmcontrol 		0x10
+set dmcontrol_dmactive	[expr {1 << 0}]
+set dmcontrol_haltreq	[expr {1 << 31}]
+
+# By spec, ndmreset should reset whole chip. This implementation resets only few parts of the chip.
+# CTRL_PWRON_RESET register in GLB core triggers full "power-on like" reset, so we use it instead
+# for full software reset.
+$_TARGETNAME configure -event reset-assert {
+	halt
+
+	# To stay in BootROM until JTAG re-attaches, we are using BootROM functionality
+	# to force ISP mode, so BootROM looks out for external ISP communication.
+
+	# In HBN_RSV2, set HBN_RELEASE_CORE to HBN_RELEASE_CORE_FLAG (4)
+	# and HBN_USER_BOOT_SEL to 1 (ISP)
+	mww 0x2000f108 0x44000000
+
+	# Switch clock to internal RC32M
+	# In HBN_GLB, set ROOT_CLK_SEL = 0
+	mmw 0x2000f030 0x0 0x00000002
+
+	# In GLB_SYS_CFG0, set REG_BCLK_DIV and REG_HCLK_DIV = 0
+	mmw 0x20000090 0x0 0x00FFFF00
+
+	# Trigger BCLK ACT pulse
+	# In GLB_SYS_CFG1, set BCLK_DIV_ACT_PULSE = 1
+	mmw 0x20000094 0x1 0x00000001
+	# In GLB_SYS_CFG1, wait for GLB_STS_BCLK_PROT_DONE to become 1
+	while { [expr {[mrw 0x20000094] & 4}] == 0 } { sleep 1 }
+
+	# In GLB_SWRST_CFG2, clear CTRL_PWRON_RESET
+	mmw 0x20000548 0x0 0x00000001
+
+	# This Software reset method resets everything, so CPU as well.
+	# It does that in not much good way, resulting in Debug Module being reset as well.
+	# This also means, that right after CPU and Debug Module are turned on, we need to
+	# enable Debug Module and halt CPU if needed. Additionally, we trigger this SW reset
+	# through program buffer access directly with DMI commands, to avoid errors printed by
+	# OpenOCD about unsuccessful register write.
+
+	# In GLB_SWRST_CFG2, set CTRL_PWRON_RESET to 1
+	set_reg {fp 0x20000548 s1 0x01}
+	riscv dmi_write 0x20 0x00942023
+	riscv dmi_write 0x17 0x40000
+
+	# We need to wait for chip to finish reset and execute BootROM
+	sleep 10
+
+	# JTAG Debug Transport Module is reset as well, so we need to get into RUN/IDLE state
+	runtest 10
+
+	# We need to enable Debug Module and halt the CPU, so we can reset Program Counter
+	# and to do additional clean-ups. If reset was called without halt, resume is handled
+	# by reset-deassert-post event handler.
+
+	# In Debug Module Control (dmcontrol), set dmactive to 1 and then haltreq to 1
+	riscv dmi_write $::dmcontrol $::dmcontrol_dmactive
+	riscv dmi_write $::dmcontrol [ expr {$::dmcontrol_dmactive | $::dmcontrol_haltreq} ]
+}
+
+$_TARGETNAME configure -event reset-deassert-post {
+	# Set Program Counter to start of BootROM and execute one instruction
+	step 0x90000000
+
+	# When using default JTAG pinout, BOOT pin is the same as JTAG TDO pin.
+	# Since after reset we set PC to start of the BootROM,
+	# BootROM will execute also check of BOOT pin, which will disable TDO pin,
+	# to check the BOOT pin state. This leads to temporary loss of JTAG access
+	# and causes (recoverable) errors in OpenOCD. We can bypass the BOOT pin check
+	# function, by forcing booting from Media/SPI Flash.
+
+	# In HBN_RSV2, set HBN_RELEASE_CORE to HBN_RELEASE_CORE_FLAG (4)
+	# and HBN_USER_BOOT_SEL to 2 (Media/SPI Flash)
+	mww 0x2000f108 0x48000000
+
+	# Resume the processor if reset was triggered without halt request
+	if {$halt == 0} {
+		resume
+	}
+}
+
+# According to JTAG spec (IEEE 1149.1), when chip enters "Test-Logic-Reset" state,
+# the IR instruction should be set to "IDCODE" or "BYPASS" (when chip does not have IDCODE).
+# This is done so automatic chain scan can detect all the chips within JTAG chain without knowing IDCODE.
+# JTAG Debug Transport Module (DTM) used in this chip, developed by T-Head (formerly C-Sky)
+# does not implement this, so OpenOCD can't detect the chip anymore after the IR instruction is changed.
+# This workaround gets chip into known state, and manually set IR instruction to IDCODE,
+# which is 0x01, standardized by RISC-V Debug Specification.
+proc init_reset { mode } {
+	if {[using_jtag]} {
+		# Get JTAG SM to known state
+		runtest 10
+		# Set IR to IDCODE
+		irscan $::_CHIPNAME.cpu 0x01
+		jtag arp_init-reset
+	}
+}
+
+proc jtag_init {} {
+	# Get JTAG SM to known state
+	runtest 10
+	# Set IR to IDCODE
+	irscan $::_CHIPNAME.cpu 0x01
+
+	if {[catch {jtag arp_init} err]!=0} {
+		# try resetting additionally
+		init_reset startup
+	}
+}

--- a/tcl/target/bl702.cfg
+++ b/tcl/target/bl702.cfg
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Bouffalo Labs BL702, BL704 and BL706 target
+#
+# https://en.bouffalolab.com/product/?type=detail&id=8
+#
+# Default JTAG pins: (if not changed by eFuse configuration)
+# TMS - GPIO0
+# TDI - GPIO1
+# TCK - GPIO2
+# TDO - GPIO9
+#
+
+source [find mem_helper.tcl]
+
+transport select jtag
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME bl702
+}
+
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x20000e05
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+riscv set_mem_access sysbus
+
+$_TARGETNAME configure -work-area-phys 0x22020000 -work-area-size 0x10000 -work-area-backup 1
+
+# Internal RC ticks on 32 MHz, so this speed should be safe to use.
+adapter speed 4000
+
+$_TARGETNAME configure -event reset-assert-pre {
+	halt
+
+	# Switch clock to internal RC32M
+	# In HBN_GLB, set ROOT_CLK_SEL = 0
+	mmw 0x4000f030 0x0 0x00000003
+	# Wait for clock switch
+	sleep 10
+
+	# GLB_REG_BCLK_DIS_FALSE
+	mww 0x40000ffc 0x0
+
+	# HCLK is RC32M, so BCLK/HCLK doesn't need divider
+	# In GLB_CLK_CFG0, set BCLK_DIV = 0 and HCLK_DIV = 0
+	mmw 0x40000000 0x0 0x00FFFF00
+	# Wait for clock to stabilize
+	sleep 10
+
+	# Do reset
+	# In GLB_SWRST_CFG2, clear CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET
+	mmw 0x40000018 0x0 0x00000007
+	# In GLB_SWRST_CFG2, set CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET to 1
+	mmw 0x40000018 0x6 0x0
+}

--- a/tcl/target/bl702.cfg
+++ b/tcl/target/bl702.cfg
@@ -34,6 +34,10 @@ $_TARGETNAME configure -work-area-phys 0x22020000 -work-area-size 0x10000 -work-
 # Internal RC ticks on 32 MHz, so this speed should be safe to use.
 adapter speed 4000
 
+# Debug Module's ndmreset resets only Trust Zone Controller, so we need to do SW reset instead.
+# CTRL_PWRON_RESET triggers full "power-on like" reset.
+# This means that pinmux configuration to access JTAG is reset as well, and configured back early
+# in BootROM.
 $_TARGETNAME configure -event reset-assert-pre {
 	halt
 
@@ -55,6 +59,15 @@ $_TARGETNAME configure -event reset-assert-pre {
 	# Do reset
 	# In GLB_SWRST_CFG2, clear CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET
 	mmw 0x40000018 0x0 0x00000007
+
+	# Since this full software reset resets GPIO pinmux as well, we will lose access
+	# to JTAG right away after writing to register. This chip doesn't support abstract
+	# memory access, so when this is done by progbuf or sysbus, OpenOCD will fail to read
+	# if write was successful or not, and will print error about that. Since receiving of
+	# this error is expected, we will turn off log printing for a moment,
+	set lvl [lindex [debug_level] 1]
+	debug_level -1
 	# In GLB_SWRST_CFG2, set CTRL_SYS_RESET, CTRL_CPU_RESET and CTRL_PWRON_RESET to 1
-	mmw 0x40000018 0x6 0x0
+	catch {mmw 0x40000018 0x7 0x0}
+	debug_level $lvl
 }

--- a/tcl/target/bl702l.cfg
+++ b/tcl/target/bl702l.cfg
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#
+# Bouffalo Labs BL702L and BL704L target
+#
+# https://en.bouffalolab.com/product/?type=detail&id=26
+#
+# Default JTAG pins: (if not changed by eFuse configuration)
+# TMS - GPIO0
+# TDI - GPIO1
+# TCK - GPIO2
+# TDO - GPIO7
+#
+
+if { [info exists CHIPNAME] } {
+	set BL602_CHIPNAME $CHIPNAME
+} else {
+	set BL602_CHIPNAME bl702l
+}
+
+set CPUTAPID 0x20000e05
+
+# For work-area we use beginning of OCRAM, since BL702L have only ITCM, which can be taken
+# by L1 cache and XIP during runtime.
+set WORKAREAADDR 0x42020000
+set WORKAREASIZE 0x10000
+
+source [find target/bl602_common.cfg]
+
+# JTAG reset is broken. Read comment of bl602_sw_reset function for more information
+# On BL702L, we are forcing boot into ISP mode, so chip stays in BootROM until JTAG re-attach
+$_TARGETNAME configure -event reset-assert {
+	halt
+
+	# Restore clocks to defaults
+	bl602_restore_clock_defaults
+
+	# In HBN_RSV2, set HBN_RELEASE_CORE to HBN_RELEASE_CORE_FLAG (4)
+	# and HBN_USER_BOOT_SEL to 1 (ISP)
+	mww 0x4000f108 0x44000000
+
+	# Perform software reset
+	bl602_sw_reset
+
+	# Reset HBN_RSV2 so BootROM will not force ISP mode again
+	mww 0x4000f108 0x00000000
+}


### PR DESCRIPTION
This Pull Request contains commits upstreamed in OpenOCD, which adds initial support for Bouffalo Lab chips, with fully working reset. Flash driver is not merged yet in upstream. Support for those chips should be part of Zephyr in upcoming release.