### PR TITLE
tcl: Add missing interface file - esp_usb_jtag.cfg

### DIFF
--- a/tcl/interface/esp_usb_jtag.cfg
+++ b/tcl/interface/esp_usb_jtag.cfg
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Espressif builtin USB-JTAG adapter
+#
+
+adapter driver esp_usb_jtag
+
+espusbjtag vid_pid 0x303a 0x1001
+espusbjtag caps_descriptor 0x2000


### PR DESCRIPTION
This PR adds a missing interface configuration file for the ESP USB JTAG adapter, which is used for debugging ESP32-S3 and similar SoCs featuring an integrated USB-to-JTAG bridge.

Since OpenOCD v0.12.0 introduced support for the ESP32-S3 MCU, a corresponding TCL interface file for the Espressif built-in USB-JTAG debugger (esp_usb_jtag.cfg) should be included, as it already exists in the main OpenOCD GitHub repository.

Adding this file ensures that users can seamlessly connect to ESP32-S3 boards using the onboard USB JTAG interface without relying on external configuration files. It also improves compatibility with Zephyr’s west debug and west debugserver workflows, providing a more consistent experience across different environments.

 