### PR TITLE
.github: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--
+**IMPORTANT NOTICE**
+This repository is a fork of OpenOCD with Zephyr-specific patches to support
+building Zephyr SDK.
+
+All pull requests here must be accompanied by a pull request in the Zephyr SDK
+repository [1] updating the `openocd` submodule to the pull request commit.
+
+Refer to the "Submodule Update Process" [1] and previous pull requests updating
+the OpenOCD submodule for more details.
+
+[1] https://github.com/zephyrproject-rtos/sdk-ng
+[2] https://github.com/zephyrproject-rtos/sdk-ng?tab=readme-ov-file#submodule-update-process
+-->


### PR DESCRIPTION
Add a pull request template that describes the required procedure for making pull requests to the Zephyr OpenOCD fork.